### PR TITLE
add augmentations in blender

### DIFF
--- a/trajectory_optimization/scripts/blender.py
+++ b/trajectory_optimization/scripts/blender.py
@@ -1,4 +1,6 @@
 # copy paste into blender
+import random
+
 import bpy
 import mathutils
 import numpy as np
@@ -33,11 +35,12 @@ def plot_line(filepath, name):
     curve_object.data.bevel_depth = 0.05 / 2  # 5 cm
 
     # Create a new white material
-    material = bpy.data.materials.new(name="White Material")
-    material.diffuse_color = (1, 1, 1, 1)  # RGBA white color
+    # material = bpy.data.materials.new(name="White Material")
+    # material.diffuse_color = (1, 1, 1, 1)  # RGBA white color
 
     # Assign the material to the curve
-    curve_object.data.materials.append(material)
+    # curve_object.data.materials.append(material)
+    # do this by hand, else it creates a new material each time we run
 
     # flatten the tube, make it a strip
     curve_object.scale = (1, 1, 0.01)
@@ -56,21 +59,24 @@ def create_animation(traj_path):
     car_orientations = traj[:, 2].reshape(-1, 1)  # List of Euler(yaw) for each frame
     # car_orientations = np.radians(car_orientations)
     car_orientations = np.pad(car_orientations, ((0, 0), (2, 0)))  # add pitch = 0, roll = 0
+    end_of_sequence = traj[:, -1]
 
     # Camera offset from car
-    camera_offset_position = mathutils.Vector((0.105, 0, 0.134))  # x, y, z
+    camera_offset_position = mathutils.Vector((0.105, 0, 0.170))  # x, y, z
     camera_offset_rotation = mathutils.Euler(
         (np.radians(90) + np.radians(-12), np.radians(0), np.radians(-90))
     )
 
-    # Define camera FOV
-    camera_fov = np.radians(160)  # In radians TODO set it in mm instead? 3.15mm
-    # set sensor size horizontal 3.6mm?
-
     # Create a new camera object
     bpy.ops.object.camera_add(location=(0, 0, 0))
     camera = bpy.context.object
-    camera.data.angle = camera_fov
+
+    # Define camera FOV
+    camera_fov = np.radians(132)
+    camera.data.lens_unit = "FOV"
+    camera.data.angle = camera_fov  # ~= 0.87 mm not working for some reason?
+    camera.data.sensor_fit = "HORIZONTAL"
+    camera.data.sensor_width = 3.92
 
     # Set camera to be the active camera
     bpy.context.scene.camera = camera
@@ -78,8 +84,11 @@ def create_animation(traj_path):
     # Make sure you have as many frames as you have positions and orientations
     bpy.context.scene.frame_end = len(car_positions)
 
+    # TODO select relevant objects once
+    # delete all keyframes
+
     # Iterate over each frame
-    for frame in range(len(car_positions)):
+    for frame in range(1, len(car_positions)):
         # Set the current frame
         bpy.context.scene.frame_set(frame)
 
@@ -99,10 +108,65 @@ def create_animation(traj_path):
         camera.keyframe_insert(data_path="location", frame=frame)
         camera.keyframe_insert(data_path="rotation_euler", frame=frame)
 
-    # Render the animation
-    # bpy.ops.render.render(animation=True, write_still=True)
+        # Augmentations!
+        if end_of_sequence[frame - 1]:
+            # Ground augmentation
+            ground_1 = bpy.data.objects["ground_1"]
+            ground_2 = bpy.data.objects["ground_2"]
+            ground_1.hide_render = True
+            ground_2.hide_render = True
+
+            ground_2_material = bpy.data.materials["ground_2_material"]
+            ground_2_material.keyframe_insert(
+                data_path="diffuse_color", frame=frame - 1
+            )  # keyframe
+            grey_value = random.uniform(0, 0.5)  # light grey to dark grey
+            random_grey = [grey_value, grey_value, grey_value]  # RGB
+            ground_2_material.diffuse_color = random_grey + [1.0]  # Add alpha channel
+            ground_2_material.keyframe_insert(data_path="diffuse_color", frame=frame)  # keyframe
+
+            # randomly show either ground_1 or ground_2
+            if random.random() < 0.5:
+                ground_1.hide_render = False
+            else:
+                ground_2.hide_render = False
+
+            # Insert keyframes for the objects' visibility
+            ground_1.keyframe_insert(data_path="hide_render", frame=frame)
+            ground_2.keyframe_insert(data_path="hide_render", frame=frame)
+
+            # Light augmentation
+            sun_light = bpy.data.lights["Sun"]
+            sun_light.keyframe_insert(data_path="energy", frame=frame - 1)
+            sun_light.keyframe_insert(data_path="color", frame=frame - 1)
+            color_options = [
+                [1, 1, 1],  # white
+                [0.8, 0.8, 1],  # slightly blue
+                [1, 1, 0.8],
+            ]  # slightly yellow
+
+            chosen_color = random.choice(color_options)
+
+            sun_light.color = chosen_color
+            sun_light.energy = random.uniform(0, 10)
+
+            # Insert a keyframe for the light's energy and color
+            sun_light.keyframe_insert(data_path="energy", frame=frame)
+            sun_light.keyframe_insert(data_path="color", frame=frame)
+
+            # Line augmentation
+            line_material = bpy.data.materials["line_material"]
+            line_material.keyframe_insert(data_path="diffuse_color", frame=frame - 1)  # keyframe
+            base_color = random.uniform(
+                0.75, 1.25
+            )  # This will result in a range of colors around white/beige
+            line_material.diffuse_color = [
+                base_color,
+                base_color,
+                base_color,
+                1.0,
+            ]  # Add alpha channel
+            line_material.keyframe_insert(data_path="diffuse_color", frame=frame)  # keyframe
 
 
-create_animation(
-    "/Users/armandpl/Dev/skyline/trajectory_optimization/data/centerline_trajectories.txt"
-)
+create_animation("/Users/armandpl/Dev/skyline/trajectory_optimization/data/rl_trajectories.txt")


### PR DESCRIPTION
- wrote blender bpy code to take in trajectories and track data then generate keyframes and objects to create a synth dataset
- included some light augmentations, e.g light changes in lines and light color, randomly use the tiled floor or a random shade of grey, random light intensity etc...

left to do:
- if troubles when trying to infer on real images:
  - look into camera calibration, current camera pose might not be really accurate (measured by hand + used cad data for rotation)
  - camera intrinsinc might be somewhat off as well?
    - for example: the focal lenght is 0.87mm and blender only accepts 1mm so I had to use fov degrees instead. I selected 132 deg which seem to correspond to 0.87 but the camera is supposed to be 200 fov so there are details I don't understand
   - i guess it'll be clearer when trying to infer on real images
- use wandb artifacts to #13  